### PR TITLE
Fix port arg handling in MCP servers

### DIFF
--- a/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/server.py
+++ b/src/aws-diagram-mcp-server/awslabs/aws_diagram_mcp_server/server.py
@@ -264,9 +264,11 @@ def main():
 
     args = parser.parse_args()
 
+    # Always respect the provided port
+    mcp.settings.port = args.port
+
     # Run server with appropriate transport
     if args.sse:
-        mcp.settings.port = args.port
         mcp.run(transport='sse')
     else:
         mcp.run()

--- a/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server.py
+++ b/src/aws-documentation-mcp-server/awslabs/aws_documentation_mcp_server/server.py
@@ -412,10 +412,12 @@ def main():
     # Log startup information
     logger.info('Starting AWS Documentation MCP Server')
 
+    # Always respect the provided port
+    mcp.settings.port = args.port
+
     # Run server with appropriate transport
     if args.sse:
         logger.info(f'Using SSE transport on port {args.port}')
-        mcp.settings.port = args.port
         mcp.run(transport='sse')
     else:
         logger.info('Using standard stdio transport')

--- a/src/aws-documentation-mcp-server/pyproject.toml
+++ b/src/aws-documentation-mcp-server/pyproject.toml
@@ -103,7 +103,7 @@ version = "0.0.1"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",
-    "awslabs/aws-documentation_mcp_server.__init__py:__version__"
+    "awslabs/aws_documentation_mcp_server/__init__.py:__version__",
 ]
 update_changelog_on_bump = true
 

--- a/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
+++ b/src/bedrock-kb-retrieval-mcp-server/awslabs/bedrock_kb_retrieval_mcp_server/server.py
@@ -179,9 +179,11 @@ def main():
 
     args = parser.parse_args()
 
+    # Always respect the provided port
+    mcp.settings.port = args.port
+
     # Run server with appropriate transport
     if args.sse:
-        mcp.settings.port = args.port
         mcp.run(transport='sse')
     else:
         mcp.run()

--- a/src/cdk-mcp-server/awslabs/cdk_mcp_server/core/server.py
+++ b/src/cdk-mcp-server/awslabs/cdk_mcp_server/core/server.py
@@ -74,9 +74,11 @@ def main():
 
     args = parser.parse_args()
 
+    # Always respect the provided port
+    mcp.settings.port = args.port
+
     # Run server with appropriate transport
     if args.sse:
-        mcp.settings.port = args.port
         mcp.run(transport='sse')
     else:
         mcp.run()

--- a/src/cdk-mcp-server/tests/core/test_server.py
+++ b/src/cdk-mcp-server/tests/core/test_server.py
@@ -53,3 +53,12 @@ def test_main_with_sse_args(mock_run):
         main()
         assert mcp.settings.port == 9999
         mock_run.assert_called_once_with(transport='sse')
+
+
+@patch('awslabs.cdk_mcp_server.core.server.mcp.run')
+def test_main_with_custom_port_no_sse(mock_run):
+    """Test main function with port specified but without SSE."""
+    with patch('sys.argv', ['server.py', '--port', '9998']):
+        main()
+        assert mcp.settings.port == 9998
+        mock_run.assert_called_once_with()

--- a/src/core-mcp-server/awslabs/core_mcp_server/server.py
+++ b/src/core-mcp-server/awslabs/core_mcp_server/server.py
@@ -81,9 +81,11 @@ def main() -> None:
     parser.add_argument('--port', type=int, default=8888, help='Port to run the server on')
     args = parser.parse_args()
 
+    # Always respect the provided port
+    mcp.settings.port = args.port
+
     # Run server with appropriate transport
     if args.sse:
-        mcp.settings.port = args.port
         mcp.run(transport='sse')
     else:
         mcp.run()

--- a/src/core-mcp-server/tests/test_main.py
+++ b/src/core-mcp-server/tests/test_main.py
@@ -44,6 +44,17 @@ class TestMain:
 
         assert mcp.settings.port == 9999
 
+    @patch('awslabs.core_mcp_server.server.mcp.run')
+    @patch('sys.argv', ['awslabs.core-mcp-server', '--port', '9998'])
+    def test_main_custom_port_no_sse(self, mock_run):
+        """Test main function sets port even without SSE."""
+        main()
+
+        mock_run.assert_called_once()
+        from awslabs.core_mcp_server.server import mcp
+
+        assert mcp.settings.port == 9998
+
     def test_module_execution(self):
         """Test the module execution when run as __main__."""
         # This test directly executes the code in the if __name__ == '__main__': block

--- a/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
+++ b/src/cost-analysis-mcp-server/awslabs/cost_analysis_mcp_server/server.py
@@ -516,9 +516,11 @@ def main():
 
     args = parser.parse_args()
 
+    # Always respect the provided port
+    mcp.settings.port = args.port
+
     # Run server with appropriate transport
     if args.sse:
-        mcp.settings.port = args.port
         mcp.run(transport='sse')
     else:
         mcp.run()

--- a/src/lambda-mcp-server/awslabs/lambda_mcp_server/server.py
+++ b/src/lambda-mcp-server/awslabs/lambda_mcp_server/server.py
@@ -217,9 +217,11 @@ def main():
 
     register_lambda_functions()
 
+    # Always respect the provided port
+    mcp.settings.port = args.port
+
     # Run server with appropriate transport
     if args.sse:
-        mcp.settings.port = args.port
         mcp.run(transport='sse')
     else:
         mcp.run()

--- a/src/nova-canvas-mcp-server/awslabs/nova_canvas_mcp_server/server.py
+++ b/src/nova-canvas-mcp-server/awslabs/nova_canvas_mcp_server/server.py
@@ -326,10 +326,12 @@ def main():
     args = parser.parse_args()
     logger.debug(f'Parsed arguments: sse={args.sse}, port={args.port}')
 
+    # Always respect the provided port
+    mcp.settings.port = args.port
+
     # Run server with appropriate transport
     if args.sse:
         logger.info(f'Using SSE transport on port {args.port}')
-        mcp.settings.port = args.port
         mcp.run(transport='sse')
     else:
         logger.info('Using standard stdio transport')

--- a/src/terraform-mcp-server/awslabs/terraform_mcp_server/server.py
+++ b/src/terraform-mcp-server/awslabs/terraform_mcp_server/server.py
@@ -317,9 +317,11 @@ def main():
 
     args = parser.parse_args()
 
+    # Always respect the provided port
+    mcp.settings.port = args.port
+
     # Run server with appropriate transport
     if args.sse:
-        mcp.settings.port = args.port
         mcp.run(transport='sse')
     else:
         mcp.run()


### PR DESCRIPTION
## Summary
- ensure each server honors the `--port` flag whether or not SSE transport is used
- adjust tests for core and CDK servers accordingly
- correct version file path in AWS documentation server configuration

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: command not found)*